### PR TITLE
use docker image pull

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,12 @@
 docker_builder:
   env:
-    DOCKER_USERNAME: ENCRYPTED[c228addfdb7e314adf5d7960ae16151648da51aa31d191d9d27cf92e426fc060577971cb9d197429bf67192cd7bb4b05]
-    DOCKER_PASSWORD: ENCRYPTED[c9321fca5a5e629378f55a1af05c22def4bc5976529f91364882996920fbb3855d814929a39e1b092799dc86a78b4488]
-
-  pull_script: docker pull bjlittle/s2geometry:latest || true 
+    DOCKER_USERNAME: "ENCRYPTED\
+                      [c228addfdb7e314adf5d7960ae16151648da51aa31d191d9\
+                      d27cf92e426fc060577971cb9d197429bf67192cd7bb4b05]"
+    DOCKER_PASSWORD: "ENCRYPTED\
+                      [c9321fca5a5e629378f55a1af05c22def4bc5976529f9136\
+                      4882996920fbb3855d814929a39e1b092799dc86a78b4488]"
+  pull_script: docker image pull bjlittle/s2geometry:latest || true
   build_script: docker build --cache-from bjlittle/s2geometry:latest --tag bjlittle/s2geometry context/.
   tag_script: docker tag bjlittle/s2geometry bjlittle/s2geometry:${CIRRUS_BUILD_ID}
   login_script: echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin


### PR DESCRIPTION
This PR updates `.cirrus-ci` to use the `docker image pull` command.